### PR TITLE
Hapi 6.8.0

### DIFF
--- a/aws-repo-notes.txt
+++ b/aws-repo-notes.txt
@@ -23,11 +23,11 @@ mvn clean install
 docker build -t fhir-validator-r4 .
 
 docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:latest
-docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.6.2
+docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.8.0
 
 docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:latest
 
-docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.6.2
+docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.8.0
 
 
 

--- a/aws-repo-notes.txt
+++ b/aws-repo-notes.txt
@@ -23,11 +23,11 @@ mvn clean install
 docker build -t fhir-validator-r4 .
 
 docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:latest
-docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:2.10.0
+docker tag fhir-validator-r4:latest 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.6.2
 
 docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:latest
 
-docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:2.10.0
+docker push 365027538941.dkr.ecr.eu-west-2.amazonaws.com/fhir-validator-r4:6.6.2
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>2.7.12</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>uk.nhs.england</groupId>
@@ -17,7 +17,7 @@
     <properties>
         <java.version>1.8</java.version>
         <kotlin.version>1.6.21</kotlin.version>
-        <fhir.version>6.6.0</fhir.version>
+        <fhir.version>6.6.2</fhir.version>
         <swagger_version>2.1.12</swagger_version>
         <parser_version>2.0.30</parser_version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,16 +10,17 @@
     </parent>
     <groupId>uk.nhs.england</groupId>
     <artifactId>IOPS-FHIR-Validation-Service</artifactId>
-    <version>6.6.2</version>
+    <version>6.8.0</version>
     <name>IOPS-FHIR-Validation-Service</name>
     <description>HAPI FHIR Validator using Spring Boot</description>
 
     <properties>
         <java.version>1.8</java.version>
         <kotlin.version>1.6.21</kotlin.version>
-        <fhir.version>6.6.2</fhir.version>
+        <fhir.version>6.8.0</fhir.version>
         <swagger_version>2.1.12</swagger_version>
         <parser_version>2.0.30</parser_version>
+        <jackson_databind_version>2.15.2</jackson_databind_version>
     </properties>
 
     <dependencies>
@@ -51,6 +52,17 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson_databind_version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson_databind_version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>uk.nhs.england</groupId>
     <artifactId>IOPS-FHIR-Validation-Service</artifactId>
-    <version>2.10.0</version>
+    <version>6.6.2</version>
     <name>IOPS-FHIR-Validation-Service</name>
     <description>HAPI FHIR Validator using Spring Boot</description>
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ fhir:
   server:
     name: IOPS FHIR Testing
     baseUrl: https://3cdzg7kbj4.execute-api.eu-west-2.amazonaws.com/poc/Conformance
-    version: 2.10.0
+    version: 6.6.2
 
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ fhir:
   server:
     name: IOPS FHIR Testing
     baseUrl: https://3cdzg7kbj4.execute-api.eu-west-2.amazonaws.com/poc/Conformance
-    version: 6.6.2
+    version: 6.8.0
 
 
 

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,11 +1,11 @@
 [
   {
     "packageName": "fhir.r4.ukcore.stu3.currentbuild",
-    "version": "0.0.5-sprint-6-review"
+    "version": "0.0.6-pre-release"
   },
   {
     "packageName": "uk.nhsdigital.r4.test",
-    "version": "2.8.8-prerelease"
+    "version": "2.8.15-prerelease"
   },
   {
     "packageName": "hl7.fhir.uv.sdc",


### PR DESCRIPTION
Hapi updated to 6.8.0 by KM, built and pushed to amazon, by KM

Testing of swagger validator, using known bad and good examples, with and without comments in xml all worked as expected
http://lb-fhir-validator-924628614.eu-west-2.elb.amazonaws.com/swagger-ui/index.html#/

I am happy to have this merged