### PR TITLE
Changes to support R5 Subscription backports (validating bundles within Bundles)

### DIFF
--- a/src/main/kotlin/uk/nhs/england/fhirvalidator/service/MessageDefinitionApplier.kt
+++ b/src/main/kotlin/uk/nhs/england/fhirvalidator/service/MessageDefinitionApplier.kt
@@ -54,11 +54,11 @@ class MessageDefinitionApplier(
         if (messageDefinitionProfile != null) {
             return messageDefinitions
                 ?.filter { it.eventCoding.system == messageType.system }
-                ?.firstOrNull { it.eventCoding.code == messageType.code &&  it.url == messageDefinitionProfile }
+                ?.lastOrNull { it.eventCoding.code == messageType.code &&  it.url == messageDefinitionProfile }
         } else {
             return messageDefinitions
                 ?.filter { it.eventCoding.system == messageType.system }
-                ?.firstOrNull { it.eventCoding.code == messageType.code }
+                ?.lastOrNull { it.eventCoding.code == messageType.code }
         }
     }
 

--- a/src/main/kotlin/uk/nhs/england/fhirvalidator/util/ProfileApplier.kt
+++ b/src/main/kotlin/uk/nhs/england/fhirvalidator/util/ProfileApplier.kt
@@ -6,7 +6,8 @@ import org.hl7.fhir.r4.model.Bundle
 
 fun getResourcesOfType(resource: IBaseResource, resourceType: String?): List<IBaseResource> {
     val matchingResources = mutableListOf<IBaseResource>()
-    if (resource.fhirType() == resourceType) {
+    // KGM exclude bundles from resource checks
+    if (resource.fhirType() == resourceType && !(resource is Bundle)) {
         matchingResources.add(resource)
     }
     if (resource is Bundle) {


### PR DESCRIPTION
Altered MessageDefintion to use the last definition it finds and ProfileApplier to ignore the root Bundle (only use child bundles), was selecting all Bundles