### PR TITLE
make meta.profile the most 'reliable', then apply message def, then apply capability

### DIFF
--- a/src/main/kotlin/uk/nhs/england/fhirvalidator/provider/ValidateR4Provider.kt
+++ b/src/main/kotlin/uk/nhs/england/fhirvalidator/provider/ValidateR4Provider.kt
@@ -203,13 +203,13 @@ class ValidateR4Provider (
             result = validator.validateWithResult(resource, ValidationOptions().addProfile(profile))
                 .toOperationOutcome() as? OperationOutcome
         } else {
-            capabilityStatementApplier.applyCapabilityStatementProfiles(resource, importProfile)
             val messageDefinitionErrors = fhirMessage.applyMessageDefinition(resource)
             if (messageDefinitionErrors != null) {
                 messageDefinitionErrors.issue.forEach{
                     additionalIssues.add(it)
                 }
             }
+            capabilityStatementApplier.applyCapabilityStatementProfiles(resource, importProfile)
             if (importProfile !== null && importProfile && resource is Bundle) fhirDocumentApplier.applyDocumentDefinition(resource)
             result = validator.validateWithResult(fhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToString(resource)).toOperationOutcome() as? OperationOutcome
         }

--- a/src/main/kotlin/uk/nhs/england/fhirvalidator/util/ProfileApplier.kt
+++ b/src/main/kotlin/uk/nhs/england/fhirvalidator/util/ProfileApplier.kt
@@ -23,10 +23,14 @@ fun getResourcesOfType(resource: IBaseResource, resourceType: String?): List<IBa
 
 fun applyProfile(resources: List<IBaseResource>, profile: String) {
     resources.stream().forEach {
-        var found = false
-        it.meta.profile.forEach {
-            if (it.value.equals(profile)) found = true
+        if (it.meta.profile.count() === 0) {
+            var found = false
+            it.meta.profile.forEach {
+                if (it.value.equals(profile)) found = true
+            }
+            if (!found) {
+                it.meta.addProfile(profile)
+            }
         }
-        if (!found) it.meta.addProfile(profile)
     }
 }


### PR DESCRIPTION
Issue found on MCED profiles in NHSE Examples repo

Process  I understood it to be was: Meta.profile cleared, first capabaility statement applied, message definition applied is suitable (clear meta.profile first)

Current process is: meta.profile not cleared, all capability statements applied, message definition applied (meta.profile NOT cleared)

This fix changes it to: if meta.profile is present do not add anything to it. 
if not present, and messagedefinition suitable, then add it. 
if still not present, add first capability statement

Essentially makes an existing meta.profile the "best"