### PR TITLE
Update to fhir 7.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<java.version>20</java.version>
 		<kotlin.version>1.9.22</kotlin.version>
-		<fhir.version>7.0.2</fhir.version>
+		<fhir.version>7.6.1</fhir.version>
 		<swagger_version>2.2.20</swagger_version>
 		<parser_version>2.1.20</parser_version>
 		<jackson_databind_version>2.17.0</jackson_databind_version>


### PR DESCRIPTION
id was previously changed without changing the fhir version. This fixes the issue