### PR TITLE
Fix typo in valueset_expansion_mode option

### DIFF
--- a/hapi.application.yaml
+++ b/hapi.application.yaml
@@ -257,7 +257,7 @@ hapi:
           # enable_expression_caching: true
         terminology:
           valueset_preexpansion_mode: IGNORE         # USE_IF_PRESENT | REQUIRE | IGNORE
-          valueset_expansion_mode: USE_EXPANSION_OPERATION   # AUTO | USE_EXPANSION_OPERATION | PERFORM_NAIVE_EXPANSION
+          valueset_expansion_mode: USE_EXPAND_OPERATION   # AUTO | USE_EXPANSION_OPERATION | PERFORM_NAIVE_EXPANSION
           valueset_membership_mode: USE_VALIDATE_CODE_OPERATION            # AUTO | USE_VALIDATE_CODE_OPERATION | USE_EXPANSION
           code_lookup_mode: USE_VALIDATE_CODE_OPERATION      # AUTO | USE_VALIDATE_CODE_OPERATION | USE_CODESYSTEM_URL
           remote_terminology:


### PR DESCRIPTION
fixes 

"
fhir-server  | ***************************
fhir-server  | APPLICATION FAILED TO START
fhir-server  | ***************************
fhir-server  | 
fhir-server  | Description:
fhir-server  | 
fhir-server  | Failed to bind properties under '[hapi.fhir.cr](http://hapi.fhir.cr).cql.terminology.valueset-expansion-mode/' to org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings$VALUESET_EXPANSION_MODE:
fhir-server  | 
fhir-server  |     Property: [hapi.fhir.cr](http://hapi.fhir.cr).cql.terminology.valueset-expansion-mode/
fhir-server  |     Value: "USE_EXPANSION_OPERATION"
fhir-server  |     Origin: URL [file:config/application.yaml] - 260:36
fhir-server  |     Reason: failed to convert java.lang.String to org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings$VALUESET_EXPANSION_MODE (caused by java.lang.IllegalArgumentException: No enum constant org.opencds.cqf.fhir.cql.engine.terminology.TerminologySettings.VALUESET_EXPANSION_MODE.USE_EXPANSION_OPERATION)
fhir-server  | 
fhir-server  | Action:
fhir-server  | 
fhir-server  | Update your application's configuration. The following values are valid:
fhir-server  | 
fhir-server  |     AUTO
fhir-server  |     PERFORM_NAIVE_EXPANSION
fhir-server  |     USE_EXPAND_OPERATION
fhir-server  | 
fhir-server exited with code 1
"