### PR TITLE
Add GitHub Actions workflow for FHIR validator image

### DIFF
--- a/.github/workflows/publish-hapi-image.yaml
+++ b/.github/workflows/publish-hapi-image.yaml
@@ -1,0 +1,35 @@
+name: Build and publish FHIR validator image
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image (latest)
+        run: |
+          IMAGE=ghcr.io/${{ github.repository_owner }}/validation-service-fhir-r4:latest
+          docker build -t $IMAGE .
+          docker push $IMAGE


### PR DESCRIPTION
allows the docker image to be built to save time running mvn package and docker compose build each time